### PR TITLE
fix(decorators-2.py): .datetime.utcnow() is deprecated replace with .now(datetime.UTC)

### DIFF
--- a/08.Decorators/decorators-2.py
+++ b/08.Decorators/decorators-2.py
@@ -9,9 +9,9 @@ import datetime
 
 def my_decorator(inner):
     def inner_decorator():
-        print(datetime.datetime.utcnow())
+        print(datetime.now(datetime.UTC))
         inner()
-        print(datetime.datetime.utcnow())
+        print(datetime.now(datetime.UTC))
 
     return inner_decorator
 

--- a/08.Decorators/decorators-3.py
+++ b/08.Decorators/decorators-3.py
@@ -12,9 +12,9 @@ import datetime
 
 def my_decorator(inner):
     def inner_decorator(num_copy):
-        print(datetime.datetime.utcnow())
+        print(datetime.now(datetime.UTC))
         inner(int(num_copy) + 1)
-        print(datetime.datetime.utcnow())
+        print(datetime.now(datetime.UTC))
 
     return inner_decorator
 


### PR DESCRIPTION
…datetime.utcnow()